### PR TITLE
Ksiega zlecen pamieta na ktorej stronie byla otwarta.

### DIFF
--- a/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
@@ -183,6 +183,8 @@ namespace Server.Engines.BulkOrders
 					break;
 				}
 			}
+
+			m_Book.LastPage = 0;
 		}
 
 		public BOBFilterGump( PlayerMobile from, BulkOrderBook book ) : base( 12, 24 )

--- a/Scripts/Engines/BulkOrders/Books/BOBGump.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBGump.cs
@@ -470,7 +470,7 @@ namespace Server.Engines.BulkOrders
 			m_List = list;
 
 			int pagesCount = GetPagesCount();
-			page = (page < pagesCount) ? page : pagesCount - 1;
+			page = Math.Min(page, pagesCount - 1);
 			m_Page = page;
 			m_Book.LastPage = m_Page;
 

--- a/Scripts/Engines/BulkOrders/Books/BulkOrderBook.cs
+++ b/Scripts/Engines/BulkOrders/Books/BulkOrderBook.cs
@@ -18,6 +18,26 @@ namespace Server.Engines.BulkOrders
 		private string m_BookName;
 		private SecureLevel m_Level;
 		private int m_UsesRemaining;
+		private int m_LastPage;
+
+		[CommandProperty(AccessLevel.GameMaster)]
+		public int Capacity
+		{
+			get { return 500; }
+		}
+
+		public int LastPage
+		{
+			// Since book page content depends on a filter, and it can use either
+			// book's or player's filter, the LastPage may work funny in case there
+			// are two players at the same time viewing the book (race condition).
+			// So the LastPage value should actually be defined per <book,filter> pair,
+			// or per <book,player> pair. However, in most use cases there will be only
+			// one player at a time using the book, so I define LastPage just per
+			// book instance, to simplify.
+			get { return m_LastPage; }
+			set { m_LastPage = value; }
+		}
 
 		[CommandProperty( AccessLevel.GameMaster )]
 		public int UsesRemaining
@@ -120,7 +140,7 @@ namespace Server.Engines.BulkOrders
 					from.SendLocalizedMessage( 1062385 ); // You must have the book in your backpack to add deeds to it.
 					return false;
 				}
-				else if ( m_Entries.Count < 500 )	
+				else if ( m_Entries.Count < Capacity )	
 				{
 					m_Entries.Add( new BOBLargeEntry( (LargeBOD)dropped ) );
 					InvalidateProperties();
@@ -146,7 +166,7 @@ namespace Server.Engines.BulkOrders
 					from.SendLocalizedMessage( 1062385 ); // You must have the book in your backpack to add deeds to it.
 					return false;
 				}
-				else if ( m_Entries.Count < 500 )	//org 500
+				else if ( m_Entries.Count < Capacity )
 				{
 					m_Entries.Add( new BOBSmallEntry( (SmallBOD)dropped ) );
 					InvalidateProperties();

--- a/Scripts/Engines/BulkOrders/Books/BulkOrderBook.cs
+++ b/Scripts/Engines/BulkOrders/Books/BulkOrderBook.cs
@@ -20,7 +20,6 @@ namespace Server.Engines.BulkOrders
 		private int m_UsesRemaining;
 		private int m_LastPage;
 
-		[CommandProperty(AccessLevel.GameMaster)]
 		public int Capacity
 		{
 			get { return 500; }


### PR DESCRIPTION
Gump księgi wyświetla bieżącą stronę: https://i.postimg.cc/vBB5N0pn/obraz.png
Jeśli PR będzie zaakceptowany to napisze analogiczny kod do księgi zleceń myśliwskich, oraz do repo SrevUO.