### PR TITLE
Zmiana nazwy: "Wioska Drowow" -> "Noamuth Quortek"

### DIFF
--- a/Data/NelderimRegions/NelderimRegions.xml
+++ b/Data/NelderimRegions/NelderimRegions.xml
@@ -413,7 +413,7 @@
 			</guard>
 		</guards>
 	</region>
-	<region name="WioskaDrowow" parent="Podmrok_A"/>
+	<region name="Noamuth_Quortek" parent="Podmrok_A"/>
 	<region name="Podmroku" parent="Podmrok_A"/>
 	<!--	<region name="Kryjowka_Drowow" parent="Podmrok_A"/>-->
 	<region name="SwiatyniaLoethe" parent="Podmrok_A"/>

--- a/Data/NelderimRegions/NelderimRegions.xml
+++ b/Data/NelderimRegions/NelderimRegions.xml
@@ -413,7 +413,7 @@
 			</guard>
 		</guards>
 	</region>
-	<region name="Noamuth_Quortek" parent="Podmrok_A"/>
+	<region name="NoamuthQuortek" parent="Podmrok_A"/>
 	<region name="Podmroku" parent="Podmrok_A"/>
 	<!--	<region name="Kryjowka_Drowow" parent="Podmrok_A"/>-->
 	<region name="SwiatyniaLoethe" parent="Podmrok_A"/>

--- a/Data/Regions.xml
+++ b/Data/Regions.xml
@@ -811,7 +811,7 @@
 			<rect x="2965" y="886" width="136" height="33" />
 			<go x="3042" y="854" z="0" />
 		</region>
-		<region type="VillageRegion" name="WioskaDrowow">
+		<region type="VillageRegion" name="Noamuth_Quortek">
 			<rect x="5867" y="229" width="95" height="59" />
 			<rect x="5851" y="300" width="26" height="60" />
 			<rect x="5877" y="301" width="141" height="53" />
@@ -820,7 +820,7 @@
 			<go x="5912" y="334" z="2" />
 			<music name="Paws" />
 		</region>
-		<region type="MiningRegion" priority="100" name="WioskaDrowow_Kopalnia">
+		<region type="MiningRegion" priority="100" name="Kopalnia_Noamuth_Quortek">
 			<rect x="5845" y="518" width="76" height="97" />
 			<go x="5909" y="550" z="4" />
 		</region>
@@ -7443,7 +7443,7 @@
 			<rect x="2353" y="1573" width="121" height="82" />
 			<go x="2935" y="1871" z="0" />
 		</region>
-		<region type="HousingRegion" name="WioskaDrowow_Housing">
+		<region type="HousingRegion" name="Noamuth_Quortek_Housing">
 			<rect x="5912" y="2762" width="61" height="30" />
 			<rect x="5977" y="2749" width="40" height="39" />
 			<rect x="5948" y="2707" width="72" height="38" />

--- a/Data/Regions.xml
+++ b/Data/Regions.xml
@@ -811,7 +811,7 @@
 			<rect x="2965" y="886" width="136" height="33" />
 			<go x="3042" y="854" z="0" />
 		</region>
-		<region type="VillageRegion" name="Noamuth_Quortek">
+		<region type="VillageRegion" name="NoamuthQuortek">
 			<rect x="5867" y="229" width="95" height="59" />
 			<rect x="5851" y="300" width="26" height="60" />
 			<rect x="5877" y="301" width="141" height="53" />
@@ -820,7 +820,7 @@
 			<go x="5912" y="334" z="2" />
 			<music name="Paws" />
 		</region>
-		<region type="MiningRegion" priority="100" name="Kopalnia_Noamuth_Quortek">
+		<region type="MiningRegion" priority="100" name="NoamuthQuortek_Kopalnia">
 			<rect x="5845" y="518" width="76" height="97" />
 			<go x="5909" y="550" z="4" />
 		</region>
@@ -7443,7 +7443,7 @@
 			<rect x="2353" y="1573" width="121" height="82" />
 			<go x="2935" y="1871" z="0" />
 		</region>
-		<region type="HousingRegion" name="Noamuth_Quortek_Housing">
+		<region type="HousingRegion" name="NoamuthQuortek_Housing">
 			<rect x="5912" y="2762" width="61" height="30" />
 			<rect x="5977" y="2749" width="40" height="39" />
 			<rect x="5948" y="2707" width="72" height="38" />

--- a/Scripts/Engines/Help/StuckMenu.cs
+++ b/Scripts/Engines/Help/StuckMenu.cs
@@ -38,7 +38,7 @@ namespace Server.Menus.Questions
                 new Point3D(999, 600, 0)
             }),
             
-                        // Wioska_Drowow    
+                        // Noamuth_Quortek (Wioska_Drowow)
             new StuckMenuEntry(1011033, new Point3D[]
             {
                 new Point3D(5940, 2752, -2)
@@ -81,7 +81,7 @@ namespace Server.Menus.Questions
             StuckMenuEntry[] entries = /*IsInSecondAgeArea( beheld ) ? m_T2AEntries :*/ m_Entries;
             
             String [] name= new String[] 
-            { "Tasandora", "Garlan"/*, "Orod", "Tirassa"*/, "Wioska_Drowow" };
+            { "Tasandora", "Garlan", "Noamuth_Quortek" };
 
             for ( int i = 0; i < entries.Length; i++ )
             {

--- a/Scripts/Gumps/WhoGump.cs
+++ b/Scripts/Gumps/WhoGump.cs
@@ -453,7 +453,7 @@ namespace Server.Gumps
 				return 51;
 			if ( TownDatabase.IsCitizenOfWhichTown(m) == Towns.Twierdza )
 				return 65;
-			if ( TownDatabase.IsCitizenOfWhichTown(m) == Towns.Wioska_Drowow )
+			if ( TownDatabase.IsCitizenOfWhichTown(m) == Towns.Noamuth_Quortek )
 				return 35;
 
 			return 945;

--- a/Scripts/Nelderim/Engines/Towns/Gumps/TownResourcesGump.cs
+++ b/Scripts/Nelderim/Engines/Towns/Gumps/TownResourcesGump.cs
@@ -1820,7 +1820,7 @@ namespace Server.Gumps
                                         m_toGive = new MiastowaSzataTwierdza();
                                         from.AddToBackpack(m_toGive);
                                         break;
-                                    case Towns.Wioska_Drowow:
+                                    case Towns.Noamuth_Quortek:
                                         TownDatabase.GetCitinzeship(from).UseDevotion(2000);
                                         m_toGive = new MiastowaSzataWioskaDrowow();
                                         from.AddToBackpack(m_toGive);
@@ -1860,7 +1860,7 @@ namespace Server.Gumps
                                         m_toGive = new MiastowaSzataZKapturemTwierdza();
                                         from.AddToBackpack(m_toGive);
                                         break;
-                                    case Towns.Wioska_Drowow:
+                                    case Towns.Noamuth_Quortek:
                                         TownDatabase.GetCitinzeship(from).UseDevotion(10000);
                                         m_toGive = new MiastowaSzataZKapturemWioskaDrowow();
                                         from.AddToBackpack(m_toGive);
@@ -1906,7 +1906,7 @@ namespace Server.Gumps
                                     //     m_toGive = new MiastowaSzataTwierdza();
                                     //     from.AddToBackpack(m_toGive);
                                     //     break;
-                                    case Towns.Wioska_Drowow:
+                                    case Towns.Noamuth_Quortek:
                                         TownDatabase.GetCitinzeship(from).UseDevotion(1000);
                                         m_toGive = new PigmentDrow();
                                         from.AddToBackpack(m_toGive);
@@ -2472,7 +2472,7 @@ namespace Server.Gumps
             AddTownButton(10, 50, Towns.Tasandora);
             AddTownButton(10, 70, Towns.Garlan);
             AddTownButton(10, 90, Towns.Twierdza);
-            AddTownButton(10, 110, Towns.Wioska_Drowow);
+            AddTownButton(10, 110, Towns.Noamuth_Quortek);
         }
 
         public override void OnResponse(NetState sender, RelayInfo info)

--- a/Scripts/Nelderim/Engines/Towns/Items/DevotionRewards/MiastowaSzata.cs
+++ b/Scripts/Nelderim/Engines/Towns/Items/DevotionRewards/MiastowaSzata.cs
@@ -178,7 +178,7 @@ namespace Server.Items
 
         public override bool CanEquip(Mobile m)
         {
-            if (TownDatabase.IsCitizenOfGivenTown(m, Towns.Wioska_Drowow))
+            if (TownDatabase.IsCitizenOfGivenTown(m, Towns.Noamuth_Quortek))
             {
                 return true;
             }
@@ -396,7 +396,7 @@ namespace Server.Items
 
         public override bool CanEquip(Mobile m)
         {
-            if (TownDatabase.IsCitizenOfGivenTown(m, Towns.Wioska_Drowow))
+            if (TownDatabase.IsCitizenOfGivenTown(m, Towns.Noamuth_Quortek))
             {
                 return true;
             }

--- a/Scripts/Nelderim/Engines/Towns/TownVariables.cs
+++ b/Scripts/Nelderim/Engines/Towns/TownVariables.cs
@@ -88,13 +88,10 @@ namespace Nelderim.Towns
     public enum Towns
     {
         None = 0,
-       // Bedwyrgard = 1,
-      //  Magizhaar = 2,
-     //  Malluan = 3,
-     Wioska_Drowow = 4,
-		Tasandora = 1,
-		Garlan = 2,
-		Twierdza = 3
+        Noamuth_Quortek = 4,    // czyli Wioska Drowów
+        Tasandora = 1,
+        Garlan = 2,
+        Twierdza = 3
     }
 
     public class TownResource

--- a/Scripts/Nelderim/Regions/NelderimRegion.cs
+++ b/Scripts/Nelderim/Regions/NelderimRegion.cs
@@ -13,6 +13,7 @@ using Server.Spells.Eighth;
 using Server.Network;
 using System.Collections.Generic;
 using System.Xml;
+using System.Text.RegularExpressions;
 
 namespace Server.Regions
 {
@@ -30,7 +31,7 @@ namespace Server.Regions
 		
 		public string PrettyName
 		{
-			get { return Name.Replace('_', ' '); }
+			get { return Regex.Replace(Name.Replace('_', ' '), @"([a-z])([A-Z])", m => string.Format("{0} {1}", m.Groups[1], m.Groups[2])); }
 		}
 			
 		public static void Initialize()


### PR DESCRIPTION
Przetestowane w nastepujacy sposob:
[add DuszaMiasta
[add TownDatabase
[add Blacksmith
- nadanie miasta Wioska_Drowow w duszy miasta
- nadanie obywatelstwa Wioska_Drowow postaci gracza
- ustawienie miasta NPCowi blacksmith na Wioska_Drowow
- zawieszenie dzialalnosci budynkowi przypisanemu do NPC w miescie Wioska_Drowow
[save

Potem zaaplikowanie zmian z powyzszego commita, odpalenie gry wczytujac powyzej stworzony save.
W efekcie:
- postac gracza w paperdolu ma obywatelstwo Noamuth_Quortek
- NPC kowal odmawia sprzedazy mowiac iz miasto nie oplacilo jego uslug
- Gump duszy miasta pokazuje nazwe miasta: Noamuth_Quortek
- przejscia pomiedzy regionami pokazuja poprawne "Twym oczom ukazuje sie Noamuth Quortek"
