### PR TITLE
Wysledzona postac znika z radaru dopiero w odleglosci 40 kratek (zamiast 20)

### DIFF
--- a/Scripts/Skills/Tracking.cs
+++ b/Scripts/Skills/Tracking.cs
@@ -313,7 +313,7 @@ namespace Server.SkillHandlers
 			{
 				Mobile m = m_List[index];
 
-				m_From.QuestArrow = new TrackArrow( m_From, m, m_Range * 2 );
+				m_From.QuestArrow = new TrackArrow( m_From, m, m_Range * 4 );
 
 				if ( Core.SE )
 					Tracking.AddInfo( m_From, m );


### PR DESCRIPTION
Zgodnie z sugestia na discord.
- Nie wpływa na odległość z jakiej można znaleźć postać;
- Wpływa jedynie na odległość, z której tracimy z oczu wcześniej wyśledzoną postać.