### PR TITLE
Wprowadzono Handlarza zwojow mocy.

### DIFF
--- a/Nelderim.csproj
+++ b/Nelderim.csproj
@@ -745,6 +745,7 @@
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Mapmaker.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Monk.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Necromancer.cs" />
+    <Compile Include="Scripts\Mobiles\Vendors\NPC\PowerScrollTrader.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Provisioner.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Scribe.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\NPC\Shipwright.cs" />
@@ -758,6 +759,7 @@
     <Compile Include="Scripts\Mobiles\Vendors\SBInfo\SBNecomancer.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\SBInfo\SBNinja.cs" />
     <Compile Include="Scripts\Mobiles\Vendors\SBInfo\SBNull.cs" />
+    <Compile Include="Scripts\Mobiles\Vendors\SBInfo\SBPowerScrollTrader.cs" />
     <Compile Include="Scripts\Nelderim\Addon\FairyTree_Addon.cs" />
     <Compile Include="Scripts\Nelderim\Addon\[RunUO 2.0 SVN] Dupre's Tents\BedRoll.cs" />
     <Compile Include="Scripts\Nelderim\Addon\[RunUO 2.0 SVN] Dupre's Tents\Chest.cs" />
@@ -1369,6 +1371,8 @@
     <Compile Include="Scripts\Nelderim\Items\Grave Digging Items\GravestoneAddon.cs" />
     <Compile Include="Scripts\Nelderim\Items\Grave Digging Items\UnearthedBones.cs" />
     <Compile Include="Scripts\Nelderim\Items\Grave Digging Items\UnearthedJewelryBox.cs" />
+    <Compile Include="Scripts\Nelderim\Items\Power Scrolls\PowerScrollLootBox.cs" />
+    <Compile Include="Scripts\Nelderim\Items\Power Scrolls\PowerScrollPowder.cs" />
     <Compile Include="Scripts\Nelderim\Items\PrzyspieszenieWilkolaka.cs" />
     <Compile Include="Scripts\Nelderim\Items\Sprinklers\CureSprinkler.cs" />
     <Compile Include="Scripts\Nelderim\Items\Sprinklers\HealSprinkler.cs" />

--- a/Scripts/Items/Special/Special Scrolls/ScrollBinderDeed.cs
+++ b/Scripts/Items/Special/Special Scrolls/ScrollBinderDeed.cs
@@ -20,6 +20,18 @@ namespace Server.Items
         private int m_Needed;
         private double m_Has;
 
+        public static bool PowerScrollsQuantityNeededForUpgrade(double scrollValue, out int quantity)
+        {
+
+            switch((int)scrollValue)
+            {
+                case 105: quantity = 8; return true;
+                case 110: quantity = 6; return true;
+                case 115: quantity = 4; return true;
+                default: quantity = 8; return false; // invalid value!
+            }
+        }
+
         [CommandProperty(AccessLevel.GameMaster)]
         public BinderType BinderType { get { return m_BinderType; } set { m_BinderType = value; InvalidateProperties(); } }
 
@@ -121,13 +133,7 @@ namespace Server.Items
                             double value = ps.Value;
                             int needed = 0;
 
-                            if (value == 105)
-                                needed = 8;
-                            else if (value == 110)
-                                needed = 6;
-                            else if (value == 115)
-                                needed = 4;
-                            else
+                            if (!PowerScrollsQuantityNeededForUpgrade(value, out needed))
                                 return;
 
                             Value = value;

--- a/Scripts/Mobiles/Vendors/BaseVendor.cs
+++ b/Scripts/Mobiles/Vendors/BaseVendor.cs
@@ -936,6 +936,11 @@ namespace Server.Mobiles
             from.Send( new EquipUpdate( pack ) );
         }
 
+        public virtual bool AllowLootType(Item item)
+        {
+            return item.IsStandardLoot();
+        }
+
         public virtual void VendorSell( Mobile from )
         {
             if ( !IsActiveBuyer )
@@ -967,7 +972,7 @@ namespace Server.Mobiles
                         if ( item is Container && ((Container)item).Items.Count != 0 )
                             continue;
 
-                        if ( item.IsStandardLoot() && item.Movable && ssi.IsSellable( item ) )
+                        if ( AllowLootType(item) && item.Movable && ssi.IsSellable( item ) )
                             table[item] = new SellItemState( item, ssi.GetSellPriceFor( item ), ssi.GetNameFor( item ) );
                     }
                 }
@@ -1632,7 +1637,7 @@ namespace Server.Mobiles
 
             foreach ( SellItemResponse resp in list )
             {
-                if ( resp.Item.RootParent != seller || resp.Amount <= 0 || !resp.Item.IsStandardLoot() || !resp.Item.Movable || (resp.Item is Container && ((Container)resp.Item).Items.Count != 0) )
+                if ( resp.Item.RootParent != seller || resp.Amount <= 0 || !AllowLootType(resp.Item) || !resp.Item.Movable || (resp.Item is Container && ((Container)resp.Item).Items.Count != 0) )
                     continue;
 
                 foreach( IShopSellInfo ssi in info )
@@ -1657,7 +1662,7 @@ namespace Server.Mobiles
 
             foreach ( SellItemResponse resp in list )
             {
-                if ( resp.Item.RootParent != seller || resp.Amount <= 0 || !resp.Item.IsStandardLoot() || !resp.Item.Movable || (resp.Item is Container && ((Container)resp.Item).Items.Count != 0) )
+                if ( resp.Item.RootParent != seller || resp.Amount <= 0 || !AllowLootType(resp.Item) || !resp.Item.Movable || (resp.Item is Container && ((Container)resp.Item).Items.Count != 0) )
                     continue;
 
                 foreach( IShopSellInfo ssi in info )

--- a/Scripts/Mobiles/Vendors/NPC/PowerScrollTrader.cs
+++ b/Scripts/Mobiles/Vendors/NPC/PowerScrollTrader.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Server.ContextMenus;
+using Server.Items;
+using Server;
+
+namespace Server.Mobiles
+{
+	public class PowerScrollTrader : BaseVendor
+	{
+		private ArrayList m_SBInfos = new ArrayList();
+		protected override ArrayList SBInfos{ get { return m_SBInfos; } }
+
+		protected override Type Currency
+		{
+			get { return typeof(PowerScrollPowder); }
+		}
+
+		public override bool CanTeach{ get{ return true; } }
+
+		[Constructable]
+		public PowerScrollTrader() : base( "- Handlarz Zwojow Mocy" )
+		{
+	
+		}
+
+		public override bool AllowLootType(Item item)
+		{
+			// Pozwol graczowi sprzedac "przeklete" itemy
+			return true;
+		}
+
+		public override void InitSBInfo()
+		{
+			m_SBInfos.Add( new SBPowerScrollTrader() );
+		}
+
+		public override VendorShoeType ShoeType
+		{
+			get{ return Utility.RandomBool() ? VendorShoeType.Shoes : VendorShoeType.Sandals; }
+		}
+
+		public override void InitOutfit()
+		{
+			base.InitOutfit();
+
+			AddItem( new Server.Items.Robe( Utility.RandomPinkHue() ) );
+		}
+		
+
+		public PowerScrollTrader( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 0 ); // version
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+		}
+	}
+}

--- a/Scripts/Mobiles/Vendors/SBInfo/SBPowerScrollTrader.cs
+++ b/Scripts/Mobiles/Vendors/SBInfo/SBPowerScrollTrader.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Server.Items;
+
+namespace Server.Mobiles
+{
+	public class SBPowerScrollTrader : SBInfo
+	{
+		private ArrayList m_BuyInfo = new InternalBuyInfo();
+		private IShopSellInfo m_SellInfo = new InternalSellInfo();
+
+		private static int BasePriceForSmallestScroll { get { return 10; } }
+
+		private static bool HowManySmallScrollsForOneBig(int bigPsValue, out int quantity)
+		{
+            int howMany105ForOne110, howMany110ForOne115, howMany115ForOne120;
+            ScrollBinderDeed.PowerScrollsQuantityNeededForUpgrade(105, out howMany105ForOne110);
+            ScrollBinderDeed.PowerScrollsQuantityNeededForUpgrade(110, out howMany110ForOne115);
+            ScrollBinderDeed.PowerScrollsQuantityNeededForUpgrade(115, out howMany115ForOne120);
+
+            switch (bigPsValue)
+            {
+                case 105: quantity = 1; return true;    // x
+                case 110: quantity = howMany105ForOne110; return true;  // 8
+				case 115: quantity = howMany105ForOne110 * howMany110ForOne115; return true;    // 8 * 6
+				case 120: quantity = howMany105ForOne110 * howMany110ForOne115 * howMany115ForOne120; return true;  // 8 * 6 * 4
+				default: quantity = 60000; return false;  // invalid value
+			}
+        }
+
+		public SBPowerScrollTrader()
+		{
+		}
+
+		public override IShopSellInfo SellInfo { get { return m_SellInfo; } }
+		public override ArrayList BuyInfo { get { return m_BuyInfo; } }
+
+		public static int GetBuyPrice(PowerScrollLootBox.PowerScrollLootType boxType)
+		{
+            int price = 60000;
+
+            double powerScrollValue = (int)boxType;
+            int numberOf105Scrolls;
+            if (HowManySmallScrollsForOneBig((int)powerScrollValue, out numberOf105Scrolls))
+            {
+				double factor = 2.0; // za zwój od handlarza zap³acimy 2x wiêcej zwojów, ni¿ w systemie zwojów ³¹czenia
+
+				price = (int)(factor * BasePriceForSmallestScroll * numberOf105Scrolls);
+            }
+
+            return price;
+        }
+
+		public class InternalBuyInfo : ArrayList
+		{
+			public InternalBuyInfo()
+			{  
+				Add( new GenericBuyInfo( typeof(PowerScrollLootBox), GetBuyPrice(PowerScrollLootBox.PowerScrollLootType.Wondrous), 50, 0x2DF3, 0 , new object[]{ PowerScrollLootBox.PowerScrollLootType.Wondrous}) );
+				Add( new GenericBuyInfo( typeof(PowerScrollLootBox), GetBuyPrice(PowerScrollLootBox.PowerScrollLootType.Exalted), 40, 0x2DF3, 0 , new object[]{ PowerScrollLootBox.PowerScrollLootType.Exalted}) );
+				Add( new GenericBuyInfo( typeof(PowerScrollLootBox), GetBuyPrice(PowerScrollLootBox.PowerScrollLootType.Mythical), 30, 0x2DF3, 0 , new object[]{ PowerScrollLootBox.PowerScrollLootType.Mythical}) );
+				Add( new GenericBuyInfo( typeof(PowerScrollLootBox), GetBuyPrice(PowerScrollLootBox.PowerScrollLootType.Legendary), 20, 0x2DF3, 0 , new object[]{ PowerScrollLootBox.PowerScrollLootType.Legendary}) );
+			}
+		}
+
+		public class InternalSellInfo : IShopSellInfo
+		{
+			private Dictionary<Type, int> m_Table = new Dictionary<Type, int>();
+			private Type[] m_Types;
+			
+			public InternalSellInfo()
+			{
+				Add(typeof(PowerScroll), 1);
+			}
+			
+			public void Add( Type type, int price )
+			{
+				m_Table[type] = price;
+				m_Types = null;
+			}
+			
+			public string GetNameFor(Item item)
+			{
+				if ( item.Name != null )
+					return item.Name;
+				return item.LabelNumber.ToString();
+			}
+
+			public int GetSellPriceFor(Item item)
+			{
+				int price = 1;
+
+				PowerScroll ps = item as PowerScroll;
+				if (ps != null)
+				{
+					int numberOf105Scrolls;
+					if (HowManySmallScrollsForOneBig((int)ps.Value, out numberOf105Scrolls))
+					{
+						price = BasePriceForSmallestScroll * numberOf105Scrolls;
+					}
+				}
+
+				return price;
+			}
+
+			public int GetBuyPriceFor(Item item)
+			{
+				return 99999;
+			}
+
+			public bool IsSellable(Item item)
+			{
+				return m_Table.ContainsKey(item.GetType());
+			}
+
+			public Type[] Types 
+			{ 
+				get 
+				{
+					if ( m_Types == null )
+					{
+						m_Types = new Type[m_Table.Keys.Count];
+						m_Table.Keys.CopyTo( m_Types, 0 );
+					}
+
+					return m_Types;
+				}
+			}
+
+			public bool IsResellable(Item item)
+			{
+				return false;
+			}
+		}
+	}
+}

--- a/Scripts/Nelderim/Items/Power Scrolls/PowerScrollLootBox.cs
+++ b/Scripts/Nelderim/Items/Power Scrolls/PowerScrollLootBox.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Configuration;
+using Server;
+using Server.Items;
+
+namespace Server
+{
+	public class PowerScrollLootBox : Item
+	{
+		public enum PowerScrollLootType
+		{
+			Wondrous = 105,
+			Exalted = 110,
+			Mythical = 115,
+			Legendary = 120
+		}
+
+		private PowerScrollLootType m_LootType;
+		
+		[CommandProperty( AccessLevel.GameMaster )]
+		public PowerScrollLootType LootType
+		{
+			get { return m_LootType; }
+			set { m_LootType = value; SetName(); }
+		}
+		
+		public override double DefaultWeight
+		{
+			get { return 0.01; }
+		}
+		
+		[Constructable]
+		public PowerScrollLootBox() : this( PowerScrollLootType.Wondrous)
+		{
+		}
+		
+		[Constructable]
+		public PowerScrollLootBox(String type) : base( 0x2DF3 )
+		{
+			if (!PowerScrollLootType.TryParse(type, out m_LootType))
+				m_LootType = PowerScrollLootType.Wondrous;
+			SetName();
+		}
+		
+		public PowerScrollLootBox(PowerScrollLootType type) : base( 0x2DF3 )
+		{
+			m_LootType = type;
+			SetName();
+		}
+		
+		public PowerScrollLootBox( Serial serial ) : base( serial )
+		{
+		}
+
+		public override void OnDoubleClick(Mobile from)
+		{
+			if(Parent != from.Backpack)
+				from.SendMessage("Nie mozesz tego uzyc");
+			else
+			{
+				switch (m_LootType)
+				{
+					case PowerScrollLootType.Wondrous: from.AddToBackpack(PowerScroll.CreateRandomNoCraft(5, 5)); break;
+					case PowerScrollLootType.Exalted: from.AddToBackpack(PowerScroll.CreateRandomNoCraft(10, 10)); break;
+					case PowerScrollLootType.Mythical: from.AddToBackpack(PowerScroll.CreateRandomNoCraft(15, 15)); break;
+					case PowerScrollLootType.Legendary: from.AddToBackpack(PowerScroll.CreateRandomNoCraft(20, 20)); break;
+				}
+				Delete();
+			}
+			base.OnDoubleClick(from);
+		}
+
+		public override void Serialize( GenericWriter writer )
+		{
+			base.Serialize( writer );
+
+			writer.Write( (int) 0 ); // version
+
+			writer.Write((int)m_LootType);
+		}
+
+		public override void Deserialize( GenericReader reader )
+		{
+			base.Deserialize( reader );
+
+			int version = reader.ReadInt();
+
+			m_LootType = (PowerScrollLootType) reader.ReadInt();
+		}
+
+		private void SetName()
+		{
+			switch (m_LootType)
+			{
+                case PowerScrollLootType.Wondrous: Name = "Skrzynia Niskiego Zwoju Mocy (105)"; break;
+                case PowerScrollLootType.Exalted: Name = "Skrzynia Średniego Zwoju Mocy (110)"; break;
+				case PowerScrollLootType.Mythical: Name = "Skrzynia Mitycznego Zwoju Mocy (115)"; break;
+				case PowerScrollLootType.Legendary: Name = "Skrzynia Legendarnego Zwoju Mocy (120)"; break;
+			}
+			InvalidateProperties();
+		}
+	}
+}

--- a/Scripts/Nelderim/Items/Power Scrolls/PowerScrollPowder.cs
+++ b/Scripts/Nelderim/Items/Power Scrolls/PowerScrollPowder.cs
@@ -1,0 +1,44 @@
+using System;
+using Server;
+
+namespace Server
+{
+    public class PowerScrollPowder : Item
+    {
+        public override double DefaultWeight
+        {
+            get { return 0.01; }
+        }
+
+        [Constructable]
+        public PowerScrollPowder() : this(1)
+        {
+        }
+
+        [Constructable]
+        public PowerScrollPowder(int amount) : base(0x26B8)
+        {
+            Name = "Pyl mocy";
+            Hue = 118;
+            Stackable = true;
+            Amount = amount;
+        }
+
+        public PowerScrollPowder(Serial serial) : base(serial)
+        {
+        }
+        public override void Serialize(GenericWriter writer)
+        {
+            base.Serialize(writer);
+
+            writer.Write((int)0); // version
+        }
+
+        public override void Deserialize(GenericReader reader)
+        {
+            base.Deserialize(reader);
+
+            int version = reader.ReadInt();
+        }
+    }
+}


### PR DESCRIPTION
Skupuje PSy, sprzedaje skrzynie generujace PSa o określonej wartości ale losowym skillu (podobne jak skrzynie artefaktów).
Waluta jest "pył mocy".
Skupuje:
- PS 105 dając 10 pyłu
- PS 110 dając 80 pyłu
- PS 115 dając 480 pyłu
- PS 120 dając 1920 pyłu
Sprzedaje:
- Skrzynia losowego PS 105 za 20 pyłu
- Skrzynia losowego PS 110 za 160 pyłu
- Skrzynia losowego PS 115 za 960 pyłu
- Skrzynia losowego PS 120 za 3840 pyłu