### PR TITLE
Nadanie drowim straznikom wygladu pajakow.

### DIFF
--- a/Data/NelderimRegions/NelderimRegions.xml
+++ b/Data/NelderimRegions/NelderimRegions.xml
@@ -145,29 +145,7 @@
 		<races None="0" Tamael="80" Jarling="10" Naur="0" Elf="0" Drow="0" Krasnolud="10"  />
 	</region>
 	<region name="Hirneth" parent="Cesarstwo"/>
-	<region name="Orod" parent="Cesarstwo">
-		<bannedschools magery="0" chivalry="0" necromancy="1" druidism="0" />
-		<bannedfollowers summons="0" familiars="1" tammed="0" tammedlimit="60"/>
-		<intolerance None="0" Tamael="0" Jarling="10" Naur="30" Elf="10" Drow="100" Krasnolud="10" />
-		<races None="0" Tamael="20" Jarling="60" Naur="0" Elf="0" Drow="0" Krasnolud="20" />
-		<guards>
-			<guard type="0" file="CesarstwoStandard" factor="0.95" span="0.75" female="0.4">
-				<races None="0" Tamael="0" Jarling="100" Naur="0" Elf="0" Drow="0" Krasnolud="0" />
-			</guard>
-			<guard type="1" file="CesarstwoMounted" factor="0.95" span="0.75" female="0.3">
-				<races None="0" Tamael="0" Jarling="100" Naur="0" Elf="0" Drow="0" Krasnolud="0" />
-			</guard>
-			<guard type="2" file="CesarstwoArcher" factor="0.95" span="0.75" female="0.5">
-				<races None="0" Tamael="0" Jarling="100" Naur="0" Elf="0" Drow="0" Krasnolud="0" />
-			</guard>
-			<guard type="3" file="CesarstwoElite" factor="0.95" span="0.75" female="0.2">
-				<races None="0" Tamael="0" Jarling="100" Naur="0" Elf="0" Drow="0" Krasnolud="0" />
-			</guard>
-			<guard type="4" file="DefaultSpecial" factor="0.95" span="0.75" female="0.5">
-				<races None="0" Tamael="0" Jarling="100" Naur="0" Elf="0" Drow="0" Krasnolud="0" />
-			</guard>
-		</guards>
-	</region>
+	<region name="Orod" parent="Cesarstwo"/>
 	<region name="Orod_Kopalnia" parent="Orod"/>
 	<region name="SrebrzystyDzban" parent="Orod"/>
 	<region name="Ethrod" parent="Cesarstwo"/>
@@ -181,48 +159,10 @@
 	<region name="SwiatyniaHurengrav" parent="Cesarstwo"/>
 	<region name="SwiatyniaHirneth" parent="Cesarstwo"/>
 	<region name="Lesniczowka" parent="Cesarstwo"/>
-	<region name="JaskiniaPrzemytnikow" parent="Default">
-		<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
-		<guards>
-			<guard type="0" file="PodmrokStandard" factor="0.8" span="0.6" female="0.75">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
-			</guard>
-			<guard type="1" file="PodmrokMounted" factor="0.8" span="0.6" female="0.8">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
-			</guard>
-			<guard type="2" file="PodmrokArcher" factor="0.8" span="0.6" female="0.75">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
-			</guard>
-			<guard type="3" file="PodmrokElite" factor="0.8" span="0.6" female="1.0">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
-			</guard>
-		</guards>
-	</region>
+	<region name="JaskiniaPrzemytnikow" parent="Default"/>
 	<region name="JaskiniaDrowow" parent="JaskiniaPrzemytnikow"/>
 
-	<region name="Twierdza" parent="Default">
-		<intolerance None="0" Tamael="10" Jarling="10" Naur="20" Elf="20" Drow="20" Krasnolud="0" />
-		<bannedschools magery="0" chivalry="0" necromancy="0" druidism="0"/>
-		<bannedfollowers summons="0" familiars="1" tammed="0" tammedlimit="60"/>
-		<races None="0" Tamael="20" Jarling="20" Naur="0" Elf="0" Drow="0" Krasnolud="60" />
-		<guards>
-			<guard type="0" file="KrasieStandard" factor="1.0" span="1.0" female="0.5">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="100" />
-			</guard>
-			<guard type="1" file="KrasieMounted" factor="1.0" span="1.0" female="0.5">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="100" />
-			</guard>
-			<guard type="2" file="KrasieArcher" factor="1.0" span="1.0" female="0.5">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="100" />
-			</guard>
-			<guard type="3" file="KrasieElite" factor="1.0" span="1.0" female="0.5">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="100" />
-			</guard>
-			<guard type="4" file="KrasieSpecial" factor="1.0" span="1.0" female="0.5">
-				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="100" />
-			</guard>
-		</guards>
-	</region>
+	<region name="Twierdza" parent="Default" />
 	<region name="Twierdza_Kopalnia" parent="Cesarstwo"/>
 	<region name="PodZelaznymMlotem" parent="Twierdza"/>
 
@@ -395,32 +335,69 @@
 	<region name="Pedanin" parent="Pedanin_Panstwo"/>
 
 	<region name="Podmrok_A" parent="Default">
-		<intolerance None="0" Tamael="80" Jarling="80" Naur="80" Elf="100" Drow="0" Krasnolud="40" />
+		<intolerance None="0" Tamael="90" Jarling="90" Naur="90" Elf="100" Drow="0" Krasnolud="90" />
 		<bannedschools magery="0" chivalry="0" necromancy="0" druidism="1"/>
 		<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" Female="0.99"/>
 		<guards>
-			<guard type="0" file="PodmrokStandard" factor="1.0" span="0.7" female="0.75">
+			<guard type="0" file="PodmrokStandard" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
-			<guard type="1" file="PodmrokMounted" factor="1.0" span="0.7" female="0.8">
+			<guard type="1" file="PodmrokArcher" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
-			<guard type="2" file="PodmrokArcher" factor="1.0" span="0.7" female="0.75">
+			<guard type="2" file="PodmrokHeavy" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
-			<guard type="3" file="PodmrokElite" factor="1.0" span="0.7" female="1.0">
+			<guard type="3" file="PodmrokMage" factor="0.95" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="4" file="PodmrokMounted" factor="0.95" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="5" file="PodmrokElite" factor="0.95" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="6" file="DefaultSpecial" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
 		</guards>
 	</region>
+	<region name="Podmrok_C" parent="Default">
+		<intolerance None="0" Tamael="100" Jarling="100" Naur="100" Elf="100" Drow="0" Krasnolud="100" />
+		<bannedschools magery="0" chivalry="0" necromancy="0" druidism="1"/>
+		<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" Female="0.99"/>
+		<guards>
+			<guard type="0" file="PodmrokStandard" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="1" file="PodmrokArcher" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="2" file="PodmrokHeavy" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="3" file="PodmrokMage" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="4" file="PodmrokMounted" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="5" file="PodmrokElite" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+			<guard type="6" file="DefaultSpecial" factor="1" span="1" female="0.5">
+				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
+			</guard>
+		</guards>
+	</region>
+	Podmrok_C
 	<region name="NoamuthQuortek" parent="Podmrok_A"/>
 	<region name="Podmroku" parent="Podmrok_A"/>
 	<!--	<region name="Kryjowka_Drowow" parent="Podmrok_A"/>-->
 	<region name="SwiatyniaLoethe" parent="Podmrok_A"/>
-	<region name="Podmrok_C" parent="Podmrok_A"/>
-	<region name="MiastoDrowow" parent="Podmrok_A"/>
-	<region name="SwiatyniaLoethe_2" parent="Podmrok_A"/>
-	<region name="KarczmaDrowow" parent="Podmrok_A"/>
+	<region name="MiastoDrowow" parent="Podmrok_C"/>
+	<region name="SwiatyniaLoethe_2" parent="Podmrok_C"/>
+	<region name="KarczmaDrowow" parent="Podmrok_C"/>
 
 	<region name="ArtTrader" parent="Default">
 		<races None="100" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="0" Krasnolud="0" Female="0.5"/>

--- a/Data/NelderimRegions/NelderimRegions.xml
+++ b/Data/NelderimRegions/NelderimRegions.xml
@@ -357,7 +357,7 @@
 			<guard type="5" file="PodmrokElite" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
-			<guard type="6" file="DefaultSpecial" factor="0.95" span="1" female="0.5">
+			<guard type="6" file="PodmrokSpecial" factor="0.95" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
 		</guards>
@@ -385,7 +385,7 @@
 			<guard type="5" file="PodmrokElite" factor="1" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
-			<guard type="6" file="DefaultSpecial" factor="1" span="1" female="0.5">
+			<guard type="6" file="PodmrokSpecial" factor="1" span="1" female="0.5">
 				<races None="0" Tamael="0" Jarling="0" Naur="0" Elf="0" Drow="100" Krasnolud="0" />
 			</guard>
 		</guards>

--- a/Data/NelderimRegions/Profiles/PodmrokArcher.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokArcher.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <export>
-	<title value="- kusznik" />
+	<nonHuman body="28" sound="904" hue="2907" name="pajak opluwacz"/>
+	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
 	<skills>
 		<skill index="1" name="Anatomy" base="120" />
 		<skill index="26" name="Resisting Spells" base="100" />
@@ -16,16 +17,11 @@
 	<hits value="300" />
 	<damage value="30" />
 	<resistances physical="30" fire="30" cold="30" poison="30" energy="30" />
-	<layers count="8">
+	<layers count="2">
 		<layer index="1" item="Server.Items.Backpack" hue="1318" loot="0">
-			<item type="Server.Items.Bolt" amount="250" hue="0" id="7163" loot="1" />
-			</layer>
-		<layer index="3" item="Server.Items.Cloak" hue="1" loot="0" />
-		<layer index="8" item="Server.Items.Bandana" hue="1890" loot="0" />
-		<layer index="10" item="Server.Items.ChainChest" hue="1890" loot="0" />
-		<layer index="16" item="Server.Items.RingmailLegs" hue="1890" loot="0" />
-		<layer index="19" item="Server.Items.Boots" hue="1890" loot="0" />
-		<layer index="20" item="Server.Items.RepeatingCrossbow" hue="1890" loot="0" />
+			<item type="Server.Items.Arrow" amount="100" hue="0" id="3903" loot="0" />
+		</layer>
+		<layer index="20" item="Server.Items.CompositeBow" hue="0" loot="0" />
 	</layers>
 	<mount mounted="false" />
 </export>

--- a/Data/NelderimRegions/Profiles/PodmrokHeavy.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokHeavy.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<export>
+	<nonHuman body="20" sound="904" hue="2907" name="pajak nadzorca"/>
+	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
+	<skills>
+		<skill index="1" name="Anatomy" base="110" />
+		<skill index="5" name="Parrying" base="110" />
+		<skill index="26" name="Resisting Spells" base="110" />
+		<skill index="27" name="Tactics" base="110" />
+		<skill index="40" name="Swordsmanship" base="110" />
+		<skill index="41" name="Mace Fighting" base="110" />
+		<skill index="42" name="Fencing" base="110" />
+		<skill index="43" name="Wrestling" base="110" />
+	</skills>
+	<stats>
+		<stat name="str" value="500" />
+		<stat name="dex" value="300" />
+		<stat name="int" value="200" />
+	</stats>
+	<hits value="600" />
+	<damage value="30" />
+	<resistances physical="55" fire="55" cold="55" poison="55" energy="55" />
+	<mount mounted="false" />
+</export>

--- a/Data/NelderimRegions/Profiles/PodmrokMage.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokMage.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<export>
+	<nonHuman body="11" sound="1170" hue="2909" name="pajak mag"/>
+	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
+	<skills>
+		<skill index="16" name="EvalInt" base="120" />
+		<skill index="26" name="Resisting Spells" base="100" />
+		<skill index="25" name="Magery" base="100" />
+		<skill index="46" name="Meditation" base="120" />
+		<skill index="41" name="Macing" base="100" />
+		<skill index="5" name="Parrying" base="100" />
+	</skills>
+	<stats>
+		<stat name="str" value="300" />
+		<stat name="dex" value="300" />
+		<stat name="int" value="500" />
+	</stats>
+	<hits value="400" />
+	<damage value="30" />
+	<resistances physical="40" fire="50" cold="50" poison="50" energy="50" />
+	<mount mounted="false" />
+</export>

--- a/Data/NelderimRegions/Profiles/PodmrokMounted.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokMounted.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <export>
-	<title value="- straznik" />
+	<nonHuman body="11" sound="1170" hue="2909" name="pajak szperacz"/>
+	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
 	<skills>
 		<skill index="1" name="Anatomy" base="100" />
 		<skill index="5" name="Parrying" base="100" />
@@ -19,12 +20,6 @@
 	<hits value="500" />
 	<damage value="35" />
 	<resistances physical="55" fire="55" cold="55" poison="55" energy="55" />
-	<layers count="9">
-		<layer index="3" item="Server.Items.Cloak" hue="237" loot="0" />
-		<layer index="10" item="Server.Items.ChainChest" hue="1890" loot="0" />
-		<layer index="16" item="Server.Items.LeatherLegs" hue="1890" loot="0" />
-		<layer index="19" item="Server.Items.Sandals" hue="1890" loot="0" />
-		<layer index="20" item="Server.Items.Pike" hue="1890" loot="0" />
-	</layers>
-	<mount type="Server.Mobiles.Nightmare" id="16039" hue="0" name="koszmar" />
+	<!-- <mount type="Server.Mobiles.Nightmare" id="16039" hue="0" name="koszmar" /> -->
+	<mount mounted="false" />
 </export>

--- a/Data/NelderimRegions/Profiles/PodmrokSpecial.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokSpecial.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <export>
-	<nonHuman body="173" sound="1170" hue="2618" name="święty pająk"/>
+	<nonHuman body="173" sound="1170" hue="2618" name="święty pająk matka"/>
 	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
 	<skills>
 		<skill index="1" name="Anatomy" base="120" />
@@ -13,12 +13,12 @@
 		<skill index="43" name="Wrestling" base="120" />
 	</skills>
 	<stats>
-		<stat name="str" value="600" />
-		<stat name="dex" value="450" />
-		<stat name="int" value="300" />
+		<stat name="str" value="1000" />
+		<stat name="dex" value="500" />
+		<stat name="int" value="500" />
 	</stats>
-	<hits value="600" />
-	<damage value="40" />
-	<resistances physical="60" fire="60" cold="60" poison="60" energy="60" />
+	<hits value="1200" />
+	<damage value="50" />
+	<resistances physical="100" fire="100" cold="100" poison="100" energy="100" />
 	<mount mounted="false" />
 </export>

--- a/Data/NelderimRegions/Profiles/PodmrokStandard.xml
+++ b/Data/NelderimRegions/Profiles/PodmrokStandard.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <export>
-	<title value="- straznik" />
+	<nonHuman body="28" sound="904" hue="2909" name="pajak straznik"/>
+	<behavior fightMode="4" isEnemyFunction="IsEnemyOfSpider"/>
 	<skills>
 		<skill index="1" name="Anatomy" base="100" />
 		<skill index="5" name="Parrying" base="100" />
@@ -19,16 +20,5 @@
 	<hits value="500" />
 	<damage value="30" />
 	<resistances physical="50" fire="50" cold="50" poison="50" energy="50" />
-	<layers count="11">
-		<layer index="0" item="Server.Items.RingmailArms" hue="1890" loot="0" />
-		<layer index="3" item="Server.Items.Cloak" hue="1" loot="1" />
-		<layer index="6" item="Server.Items.BoneGloves" hue="1890" loot="0" />
-		<layer index="8" item="Server.Items.ChainCoif" hue="1890" loot="0" />
-		<layer index="10" item="Server.Items.ChainChest" hue="1890" loot="0" />
-		<layer index="13" item="Server.Items.Longsword" hue="1105" loot="0" />
-		<layer index="16" item="Server.Items.RingmailLegs" hue="1890" loot="0" />
-		<layer index="19" item="Server.Items.Boots" hue="1890" loot="0" />
-		<layer index="20" item="Server.Items.ChaosShield" hue="1105" loot="0" />
-	</layers>
 	<mount mounted="false" />
 </export>

--- a/Scripts/Engines/AI/AI/BaseAI.cs
+++ b/Scripts/Engines/AI/AI/BaseAI.cs
@@ -2771,7 +2771,7 @@ namespace Server.Mobiles
             return (m_Mobile.FocusMob != null);
         }
 
-        private bool IsSpidersFriend(Mobile m)
+        public static bool IsSpidersFriend(Mobile m)
         {
             if (m.Race.Equals(Drow.Instance) || TownDatabase.IsCitizenOfGivenTown(m, Towns.Noamuth_Quortek))
                 return true;

--- a/Scripts/Engines/AI/AI/BaseAI.cs
+++ b/Scripts/Engines/AI/AI/BaseAI.cs
@@ -3007,7 +3007,7 @@ namespace Server.Mobiles
 
             int rand;
                 
-            if ( m_Mobile.FocusMob.Player && ( rand = Utility.Random( 0, 10 ) ) > 5 )
+            if ( m_Mobile.FocusMob.Player && ((BaseNelderimGuard)m_Mobile).IsHuman && ( rand = Utility.Random( 0, 10 ) ) > 5 )
             {
                 string msg = String.Empty;
                 switch ( rand )

--- a/Scripts/Nelderim/Mobiles/Guards/NelderimGuard.cs
+++ b/Scripts/Nelderim/Mobiles/Guards/NelderimGuard.cs
@@ -189,8 +189,14 @@ namespace Server.Mobiles
 					m_Flag = WarFlag.None;
 			}
 		}
-		
-		public BaseNelderimGuard( GuardType type ) : this( type, FightMode.Criminal )
+
+        public bool IsHuman
+		{
+			get { return BodyValue == 400 || BodyValue == 401; }
+		}
+
+
+        public BaseNelderimGuard( GuardType type ) : this( type, FightMode.Criminal )
 		{
 		}
 		

--- a/Scripts/Nelderim/Mobiles/Guards/NelderimGuard.cs
+++ b/Scripts/Nelderim/Mobiles/Guards/NelderimGuard.cs
@@ -15,6 +15,7 @@ using Server.ContextMenus;
 using Server.Gumps;
 using Server.Items;
 using Server.Nelderim;
+using System.Reflection;
 
 namespace Server.Mobiles
 {
@@ -45,8 +46,9 @@ namespace Server.Mobiles
 		private string m_RegionName;
 		private WarFlag m_Flag;
 		private WarFlag m_Enemy;
-		
-		[CommandProperty( AccessLevel.Counselor, AccessLevel.GameMaster )]
+		private string m_IsEnemyFunction;
+
+        [CommandProperty( AccessLevel.Counselor, AccessLevel.GameMaster )]
 		public string HomeRegionName
 		{
 			get
@@ -72,8 +74,38 @@ namespace Server.Mobiles
 				
 		}
 
-        // 26.06.2012 :: zombie
-        public override bool IsEnemy( Mobile m )
+        public bool IsEnemyOfSpider(Mobile m)
+		{
+            // Nie atakuj innych straznikow (obszarowka moze triggerowac walke miedzy nimi)
+			if (m is BaseNelderimGuard)
+                return false;
+
+            // nie atakuj drowow i obywatelow drowiego miasta
+            if (BaseAI.IsSpidersFriend(m))
+                return false;
+
+            // atakuj wszystkich graczy
+            if (m is PlayerMobile)
+                return true;
+
+            if (m is BaseCreature)
+            {
+                BaseCreature bc = m as BaseCreature;
+
+                // atakuj stworzenia red/krim
+                if (bc.AlwaysMurderer || bc.Criminal || (!bc.Controlled && bc.FightMode == FightMode.Closest))
+                    return true;
+
+                // atakuj pety i przywolance graczy
+                if ((bc.Controlled && bc.ControlMaster != null && bc.ControlMaster.AccessLevel < AccessLevel.Counselor) ||
+                    (bc.Summoned && bc.SummonMaster != null && bc.SummonMaster.AccessLevel < AccessLevel.Counselor))
+                    return true;
+            }
+
+            return false;
+        }
+
+        public bool IsEnemyOfDefaultGuard(Mobile m)
         {
             if ( m == null )
                 return false;
@@ -102,8 +134,30 @@ namespace Server.Mobiles
 
             return false;
         }
-        // zombie
-		public override void CriminalAction( bool message )
+
+        public override bool IsEnemy(Mobile m)
+		{
+			if (String.IsNullOrEmpty(m_IsEnemyFunction))
+			{
+				return IsEnemyOfDefaultGuard(m);
+
+            }
+			else
+			{
+				MethodInfo method = typeof(BaseNelderimGuard).GetMethod(m_IsEnemyFunction);
+				if (method != null)
+				{
+					return (bool)method.Invoke(this, new[] { m });
+				}
+				else
+				{
+					// ERROR situation, fallback to default:
+					return IsEnemyOfDefaultGuard(m);
+                }
+            }
+		}
+
+        public override void CriminalAction( bool message )
 		{
 			// Straznik nigdy nie dostanie krima.
 			// Byl problem, ze gdy straznik atakowal peta/summona gracza-krima to sam dostawal krima.s
@@ -224,15 +278,25 @@ namespace Server.Mobiles
 		{
 			get { return m_Type; }
 		}
-	
-		public override void Serialize(GenericWriter writer)
+
+        [CommandProperty(AccessLevel.Counselor, AccessLevel.GameMaster)]
+        public string IsEnemyFunction
+		{
+			get { return m_IsEnemyFunction; }
+			set { m_IsEnemyFunction = value; }
+		}
+
+        public override void Serialize(GenericWriter writer)
 		{
 			base.Serialize(writer);
 
-			writer.Write((int) 2);
-			
-			// v 2
-			writer.Write( ( int ) m_Flag );
+			writer.Write((int) 3);
+
+            // v 3
+            writer.Write( (string) m_IsEnemyFunction );
+
+            // v 2
+            writer.Write( ( int ) m_Flag );
 			writer.Write( ( int ) m_Enemy );
 			
 			// v 1
@@ -246,8 +310,13 @@ namespace Server.Mobiles
 			int version = reader.ReadInt();
 			
 			switch ( version )
-			{
-				case 2:
+            {
+                case 3:
+                    {
+                        m_IsEnemyFunction = reader.ReadString();
+                        goto case 2;
+                    }
+                case 2:
 					{
 						m_Flag = ( WarFlag ) reader.ReadInt();
 						m_Enemy = ( WarFlag ) reader.ReadInt();
@@ -312,8 +381,8 @@ namespace Server.Mobiles
 	{
 		[Constructable]
 		public StandardNelderimGuard() : base ( GuardType.StandardGuard ) {}
-	
-		public StandardNelderimGuard(Serial serial) : base(serial)
+
+        public StandardNelderimGuard(Serial serial) : base(serial)
 		{
 		}
 	
@@ -370,7 +439,7 @@ namespace Server.Mobiles
         }
 
         [Constructable]
-        public MageNelderimGuard() : base( GuardType.MageGuard, FightMode.Criminal ) { }
+        public MageNelderimGuard() : base( GuardType.MageGuard, FightMode.Criminal) { }
 
         public MageNelderimGuard( Serial serial ) : base( serial )
         {
@@ -403,7 +472,7 @@ namespace Server.Mobiles
         }
 
         [Constructable]
-        public HeavyNelderimGuard() : base( GuardType.HeavyGuard, FightMode.Criminal ) { }
+        public HeavyNelderimGuard() : base( GuardType.HeavyGuard, FightMode.Criminal) { }
 
         public HeavyNelderimGuard( Serial serial ) : base( serial )
         {
@@ -437,9 +506,9 @@ namespace Server.Mobiles
         }
 
         [Constructable]
-        public MountedNelderimGuard() : base( GuardType.MountedGuard, FightMode.Criminal ) { }
-	
-		public MountedNelderimGuard(Serial serial) : base(serial)
+        public MountedNelderimGuard() : base( GuardType.MountedGuard, FightMode.Criminal) { }
+
+        public MountedNelderimGuard(Serial serial) : base(serial)
 		{
 		}
 	
@@ -503,9 +572,9 @@ namespace Server.Mobiles
         }
 
 		[Constructable]
-        public ArcherNelderimGuard() : base( GuardType.ArcherGuard, FightMode.Criminal ) { }
-	
-		public ArcherNelderimGuard(Serial serial) : base(serial)
+        public ArcherNelderimGuard() : base( GuardType.ArcherGuard, FightMode.Criminal) { }
+
+        public ArcherNelderimGuard(Serial serial) : base(serial)
 		{
 		}
 	
@@ -569,9 +638,9 @@ namespace Server.Mobiles
         }
 
 		[Constructable]
-		public EliteNelderimGuard() : base ( GuardType.EliteGuard, FightMode.Criminal ) {}
-	
-		public EliteNelderimGuard(Serial serial) : base(serial)
+		public EliteNelderimGuard() : base ( GuardType.EliteGuard, FightMode.Criminal) {}
+
+        public EliteNelderimGuard(Serial serial) : base(serial)
 		{
 		}
 	
@@ -636,8 +705,8 @@ namespace Server.Mobiles
 
 		[Constructable]
 		public SpecialNelderimGuard() : base ( GuardType.SpecialGuard ) {}
-	
-		public SpecialNelderimGuard(Serial serial) : base(serial)
+
+        public SpecialNelderimGuard(Serial serial) : base(serial)
 		{
 		}
 	


### PR DESCRIPTION
Stworzenia typu:
- StandardNelderimGuard
- MageNelderimGuard
- HeavyNelderimGuard
- MountedNelderimGuard
- ArcherNelderimGuard
- EliteNelderimGuard
beda mialy wyglad pajakow, jesli spawnowane sa na terenie podmroku.
Beda tez miec inne zachowanie niz zwykli straznicy (atakuja wg rasy, nie wg statusu crim/red).