### PR TITLE
Ustawienie regionu dla kopalni w podmroku:

### DIFF
--- a/Data/Locations/felucca.xml
+++ b/Data/Locations/felucca.xml
@@ -116,6 +116,7 @@
 			<child name="Wioska" x="5942" y="321" z="2" />
 			<child name="Swiatynia (wioska)" x="5330" y="413" z="0" />
 			<child name="Kopalnia (wioska)" x="5906" y="549" z="4" />
+			<child name="Kopalnia (miasto)" x="5932" y="1990" z="0" />
 			<child name="Wyjscie" x="1989" y="2442" z="5" />
 			<child name="Twierdza Krasnoludow" x="5651" y="1120" z="0" />
 		</parent>
@@ -178,7 +179,8 @@
 			<child name="Ethrod" x="783" y="1468" z="-20" />
 			<child name="Saew" x="1360" y="645" z="0" />
 			<child name="Twierdzy" x="5551" y="1214" z="1" />
-			<child name="Podmroku" x="5906" y="549" z="4" />
+			<child name="Noamuth Quortek" x="5906" y="549" z="4" />
+			<child name="LDelmah" x="5932" y="1990" z="0" />
 			<child name="Zagubiona Kopalnia" x="5159" y="417" z="0" />
 		</parent>
 		<parent name="Karczmy">

--- a/Data/NelderimRegions/NelderimRegions.xml
+++ b/Data/NelderimRegions/NelderimRegions.xml
@@ -392,10 +392,12 @@
 	</region>
 	Podmrok_C
 	<region name="NoamuthQuortek" parent="Podmrok_A"/>
+	<region name="NoamuthQuortek_Kopalnia" parent="NoamuthQuortek"/>
 	<region name="Podmroku" parent="Podmrok_A"/>
 	<!--	<region name="Kryjowka_Drowow" parent="Podmrok_A"/>-->
 	<region name="SwiatyniaLoethe" parent="Podmrok_A"/>
 	<region name="MiastoDrowow" parent="Podmrok_C"/>
+	<region name="MiastoDrowow_Kopalnia" parent="MiastoDrowow"/>
 	<region name="SwiatyniaLoethe_2" parent="Podmrok_C"/>
 	<region name="KarczmaDrowow" parent="Podmrok_C"/>
 

--- a/Data/Regions.xml
+++ b/Data/Regions.xml
@@ -167,7 +167,7 @@
 			<rect x="1965" y="1531" width="108" height="102" />
 			<rect x="1974" y="1632" width="50" height="50" />
 			<rect x="2023" y="1631" width="21" height="30" />
-			<rect x="5756" y="300" width="90" height="59" />
+			<rect x="5756" y="300" width="95" height="59" />
 		</region>
 		<region type="GeographicRegion" priority="10" name="Cesarstwo">
 			<rect x="316" y="1225" width="107" height="800" />
@@ -817,10 +817,10 @@
 		<region type="VillageRegion" name="NoamuthQuortek">
 			<rect x="5867" y="229" width="95" height="59" />
 			<rect x="5851" y="300" width="26" height="60" />
-			<rect x="5877" y="301" width="141" height="53" />
+			<rect x="5877" y="301" width="135" height="53" />
 			<rect x="5877" y="288" width="78" height="13" />
 			<rect x="5877" y="354" width="101" height="25" />
-			<rect x="6018" y="313" width="92" height="60" />
+			<rect x="6012" y="313" width="98" height="60" />
 			<go x="5912" y="334" z="2" />
 			<music name="Paws" />
 		</region>
@@ -1256,11 +1256,13 @@
 			<rect x="5886" y="2255" width="67" height="39" />
 			<rect x="5867" y="229" width="95" height="59" />
 			<rect x="5851" y="300" width="26" height="60" />
-			<rect x="5877" y="301" width="141" height="53" />
+			<rect x="5877" y="301" width="135" height="53" />
 			<rect x="5877" y="288" width="78" height="13" />
 			<rect x="5877" y="354" width="101" height="25" />
-			<rect x="6018" y="313" width="92" height="60" />
+			<rect x="6012" y="313" width="98" height="60" />
 			<rect x="5306" y="334" width="51" height="84" />
+			<rect x="5756" y="300" width="95" height="59" />
+			<rect x="5845" y="518" width="76" height="97" />
 			<go x="5636" y="2771" z="30" />
 		</region>
 		<region priority="100" name="SwiatyniaLoethe">
@@ -1355,7 +1357,7 @@
 			<rect x="5448" y="2137" width="24" height="3" />
 			<go x="5622" y="2257" z="0" />
 		</region>
-		<region type="Undershadow" priority="100" name="GlebokiPodmrok">
+		<region type="Undershadow" priority="25" name="GlebokiPodmrok">
 			<rect x="5836" y="1913" width="267" height="71" />
 			<rect x="5851" y="1984" width="252" height="15" />
 			<rect x="5864" y="1999" width="253" height="15" />
@@ -7534,6 +7536,14 @@
 		<region priority="99" name="ArtTrader">
 			<rect x="1506" y="1501" width="27" height="21" />
 			<go x="1527" y="1515" z="0" />
+		</region>
+		<region type="MiningRegion" priority="100" name="MiastoDrowow_Kopalnia">
+			<rect x="5836" y="1913" width="118" height="71" />
+			<rect x="5851" y="1984" width="90" height="15" />
+			<rect x="5864" y="1999" width="77" height="15" />
+			<rect x="5866" y="2014" width="55" height="7" />
+			<rect x="5880" y="2021" width="41" height="11" />
+			<go x="5933" y="1991" z="0" />
 		</region>
 	</Facet>
 	<Facet name="Trammel" />


### PR DESCRIPTION
- Stworzony MiningRegion dla kopalni w LDelmah
- Wciagniecie kopalni pod profile regionow miast (aby straznicy byli tam pajakami)
- Drobna poprawka granic regionu mieszkalnego Noamuth Quortek oraz wiezienia Noamuth Quortek.