### PR TITLE
Fix: Stare maski zwierzat mozna kolorowac pigmentem do skor (konsekwencja commita e11f7e6c5)

### DIFF
--- a/Scripts/Nelderim/Items/Artifacts/New/Pigments/BasePigment.cs
+++ b/Scripts/Nelderim/Items/Artifacts/New/Pigments/BasePigment.cs
@@ -215,7 +215,7 @@ namespace Server.Items
                     resourcesAccepted.Add(CraftResource.SpinedLeather);
                     resourcesAccepted.Add(CraftResource.HornedLeather);
                     resourcesAccepted.Add(CraftResource.BarbedLeather);
-                    return IsInResourceList(resourcesAccepted, i) || IsInType(t, typeof(BaseQuiver));
+                    return IsInResourceList(resourcesAccepted, i) || IsInType(t, typeof(BaseQuiver)) || IsInType(t, typeof(DeerMask)) || IsInType(t, typeof(BearMask)) || IsInType(t, typeof(HornedTribalMask)) || IsInType(t, typeof(TribalMask));
                 case PigmentTarget.Wood:
                     resourcesAccepted.Add(CraftResource.RegularWood);
                     resourcesAccepted.Add(CraftResource.OakWood);


### PR DESCRIPTION
Po zmianach w:
https://github.com/UONelderim/RunUO/pull/33
pozostałe na świecie stare wersje masek jelenia/niedźwiedzia/tubylca które nadal należą do "cloth" (zamiast "armor"), więc nie działa na nie pigment skórzany. Niniejsza zmiana pozwoli barwić zarówno stare jak i nowe wersje masek (nowe już teraz można, gdyż są skórzanym armorem).