### PR TITLE
Fix: naprawiono smierc na arenie. Objasnienie:

### DIFF
--- a/Scripts/Nelderim/Engines/Arena/ArenaRegion.cs
+++ b/Scripts/Nelderim/Engines/Arena/ArenaRegion.cs
@@ -515,7 +515,7 @@ namespace Server.Regions
 			}
 		}
 
-		public override void OnDeath( Mobile m )
+		public override bool OnBeforeDeath( Mobile m )
 		{
 			FightType ft = FightType.None;
 			
@@ -572,8 +572,9 @@ namespace Server.Regions
 				Console.WriteLine( exc.ToString() );
 				m_Owner.RestartArena();
 			}
-			
-			base.OnDeath( m );
+
+			//base.OnDeath( m );
+			return false;
 		}
 		
 		#endregion


### PR DESCRIPTION
w ktorejs wersji RunUO rozbito metode klasy Region z bool OnDeath() na dwie osobne void OnBeforeDeath() i void OnDeath(). Kod areny zostal przeniesiony ze starszego RunUO bez uwzglednienia powyzszego faktu.