### PR TITLE
Rozwiazanie problemu z rzemieslnikiem nie reagujacym na slowo "zlecenie"

### DIFF
--- a/Scripts/Mobiles/Vendors/BaseVendor.cs
+++ b/Scripts/Mobiles/Vendors/BaseVendor.cs
@@ -661,10 +661,10 @@ namespace Server.Mobiles
 
             if (Regex.IsMatch(e.Speech, "zlecen", RegexOptions.IgnoreCase))
             {
-                e.Handled = true;
-
-				if (checkWillingness(e.Mobile))
+				if (SupportsBulkOrders(e.Mobile) && checkWillingness(e.Mobile))
 				{
+                    e.Handled = true;
+
                     if (e.Speech.ToLower() == "zlecen" || Regex.IsMatch(e.Speech, "^zlecen..?$", RegexOptions.IgnoreCase))
                         OnLazySpeech();
                     else


### PR DESCRIPTION
w sytuacji gdy w poblizu stoi inny NPC (ktory niepotrzebnie przechwytuje nasza wypowiedz)