### PR TITLE
Wybor surowca kowalskiego/krawieckiego w filtrze ksiegi odznaczy cieciwe.

### DIFF
--- a/Scripts/Engines/BulkOrders/Books/BOBFilter.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBFilter.cs
@@ -39,7 +39,13 @@ namespace Server.Engines.BulkOrders
 		public int Material
 		{
 			get{ return m_Material; }
-			set{ m_Material = value; }
+			set
+			{
+				m_Material = value;
+
+				if (!BOBFilterGump.IsFletcherMaterial(m_Material))
+					Material2 = 0;
+            }
 		}
 
 		public int Material2 {

--- a/Scripts/Engines/BulkOrders/Books/BOBFilter.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBFilter.cs
@@ -44,13 +44,20 @@ namespace Server.Engines.BulkOrders
 				m_Material = value;
 
 				if (!BOBFilterGump.IsFletcherMaterial(m_Material))
-					Material2 = 0;
+                    m_Material2 = 0;
             }
 		}
 
 		public int Material2 {
 			get { return m_Material2; }
-			set { m_Material2 = value; }
+			set
+			{
+				m_Material2 = value;
+
+				if (!BOBFilterGump.IsFletcherMaterial(m_Material))
+					m_Material = 0;
+
+            }
 		}
 
 		public int Quantity

--- a/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
@@ -57,9 +57,9 @@ namespace Server.Engines.BulkOrders
 			return false;
 		}
 
-		private static int[,] m_Material2Filters = new int[,]
+        private static int[,] m_Material2Filters = new int[,]
 			{
-				{       0,  0 }, // None
+				{ 1032732,  0 }, // All
 				{ 1018372,  1 }, // Bowstring Leather
 				{ 1018373,  2 }, // Bowstring Gut
 				{ 1018374,  3 }, // Bowstring Cannabis

--- a/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
+++ b/Scripts/Engines/BulkOrders/Books/BOBFilterGump.cs
@@ -50,6 +50,13 @@ namespace Server.Engines.BulkOrders
 				{       0,  0 }  // --Blank--
 			};
 
+		public static bool IsFletcherMaterial(int filterIndex)
+		{
+			if (filterIndex >= 17 && filterIndex <= 24)
+				return true;
+			return false;
+		}
+
 		private static int[,] m_Material2Filters = new int[,]
 			{
 				{       0,  0 }, // None


### PR DESCRIPTION
![obraz](https://github.com/UONelderim/RunUO/assets/103279149/666d7e5f-e95a-41d9-98bc-b8f61e0e4778)
